### PR TITLE
Flag mysql_monitor_recipient_email as required

### DIFF
--- a/install-pcf/azure/params.yml
+++ b/install-pcf/azure/params.yml
@@ -122,7 +122,7 @@ pcf_opsman_disk_size_in_gb: 120
 
 container_networking_nw_cidr: 10.255.0.0/16 # c2c networking network cidr
 
-mysql_monitor_recipient_email:  # Optional - Email address for sending mysql monitor notifications
+mysql_monitor_recipient_email: CHANGEME # Email address for sending mysql monitor notifications
 mysql_backups: disable   # Whether to enable MySQL backups. (disable|s3|scp)
 
 # SCP backup config params (leave empty values if you're not using scp)


### PR DESCRIPTION
This field is marked as optional in params, but it's not. Leaving it blank will break cause configure-ert to fail.